### PR TITLE
Add support for vitest 4

### DIFF
--- a/packages/vi-axe/src/extend-expect.ts
+++ b/packages/vi-axe/src/extend-expect.ts
@@ -15,8 +15,8 @@ interface AxeMatchers<TReturn = unknown> {
 }
 
 declare module "vitest" {
-  // oxlint-disable-next-line id-length
-  interface Matchers<T = any> extends AxeMatchers<T> {}
+  interface Matchers<T = unknown> extends AxeMatchers<T> {}
+  interface Assertion<T = unknown> extends AxeMatchers<T> {}
 }
 
 expect.extend(toHaveNoViolations as Parameters<typeof expect.extend>[0]);


### PR DESCRIPTION
vitest 4 expects `Assertion` instead of `Matchers`