### PR TITLE
Use release workflow token in the release workflow.

### DIFF
--- a/.github/workflows/release-vi-axe.yml
+++ b/.github/workflows/release-vi-axe.yml
@@ -22,9 +22,12 @@ jobs:
   release-vi-axe:
     runs-on: ubuntu-latest
     steps:
+      # Use a PAT (RELEASE_WORKFLOW_TOKEN) so push/PR events trigger CI; the default
+      # GITHUB_TOKEN does not. Add the secret under Settings → Secrets and variables → Actions.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full history needed for git log since last tag
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
 
       - name: Check for unreleased commits
         id: check
@@ -86,7 +89,7 @@ jobs:
       - name: Create release PR
         if: steps.check.outputs.has-commits == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Github doesn't run CI on PRs created via CI, so we have to use a different token to make it run them.