### PR TITLE
Update release workflow to use checkout v4 and fallback token

### DIFF
--- a/.github/workflows/release-vi-axe.yml
+++ b/.github/workflows/release-vi-axe.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       # Use a PAT (RELEASE_WORKFLOW_TOKEN) so push/PR events trigger CI; the default
       # GITHUB_TOKEN does not. Add the secret under Settings → Secrets and variables → Actions.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history needed for git log since last tag
-          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN || github.token }}
 
       - name: Check for unreleased commits
         id: check
@@ -89,7 +89,7 @@ jobs:
       - name: Create release PR
         if: steps.check.outputs.has-commits == 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_WORKFLOW_TOKEN || github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
Updated the release workflow to use a more compatible checkout action version and added fallback logic for GitHub token handling.

## Key Changes
- Downgraded `actions/checkout` from v6 to v4 for broader compatibility
- Added fallback token logic using `secrets.RELEASE_WORKFLOW_TOKEN || github.token` in two locations:
  - The checkout action's token input
  - The `GH_TOKEN` environment variable for the release PR creation step

## Implementation Details
The token fallback ensures the workflow can proceed even if the `RELEASE_WORKFLOW_TOKEN` secret is not configured, gracefully falling back to the default `github.token`. This improves workflow robustness while maintaining the ability to use a custom PAT when available for triggering downstream CI workflows.

https://claude.ai/code/session_011HVmjiNetZziAa5ry1Rvbs